### PR TITLE
feat: Add support for using @almottier's P100 fork

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,8 +154,8 @@ You can check whether your device is supported by looking at the support matrix 
 ----
 
 
-Authentication Mechanism Update
----------------------------------
+Tapo Authentication Mechanism Update
+--------------------------------------
 
 In v1.2.1 of the Tapo firmware, TP-Link changed the way that authentication happens. Devices that have received this firmware update no longer work with the version of `PyP100` in PyPi.
 
@@ -169,7 +169,35 @@ export CONF_FILE="/path/to/config"
 ./app/collect.py
 ```
 
-This *should* work with devices running new firmware as well as those that haven't been updated.
+This *should* work with devices running new firmware as well as those that haven't been updated. 
+
+However, the mixed mode support is implemented at a slight efficiency cost: it's necessary to try both auth modes to find one that succeeds.
+
+It's therefore possible to define, in config, which should be used:
+```yaml
+    devices:
+        - 
+            name: "big-fridge"
+            ip : 192.168.3.153
+            auth: "almottier_old"
+         
+        -
+            name: "slow-cooker"
+            ip: 192.168.3.164
+            auth: "package_defaults"
+            
+        -
+            name: "washing-machine"
+            ip: 192.168.3.167
+            auth: "all"
+
+```
+
+Valid values to `auth` are:
+
+- `all`: the default, will try each in turn
+- `package_defaults`: use whatever the default is for the module in use (`new` for almottier's fork, old for `PyPi`)
+- `almottier_old`: Use the `old` protocol with the Almottier fork - will fail if the PyPi version is in use instead
 
 
 Tapo vs Kasa

--- a/README.md
+++ b/README.md
@@ -136,7 +136,6 @@ And then, finally, invoke the script
 app/collect.py
 ```
 
-
 ----
 
 ## Other Stuff
@@ -153,6 +152,25 @@ You can check whether your device is supported by looking at the support matrix 
 
 
 ----
+
+
+Authentication Mechanism Update
+---------------------------------
+
+In v1.2.1 of the Tapo firmware, TP-Link changed the way that authentication happens. Devices that have received this firmware update no longer work with the version of `PyP100` in PyPi.
+
+There is, however [a fork](https://github.com/almottier/TapoP100) and [utilities/tp-link-to-influxdb#7](https://projects.bentasker.co.uk/gils_projects/issue/utilities/tp-link-to-influxdb/7.html) adds support for using it.
+
+In order to install and use a copy of the forked library, run
+```sh
+pip3 install git+https://github.com/almottier/TapoP100.git@main
+
+export CONF_FILE="/path/to/config"
+./app/collect.py
+```
+
+This *should* work with devices running new firmware as well as those that haven't been updated.
+
 
 Tapo vs Kasa
 ---------------

--- a/app/collect.py
+++ b/app/collect.py
@@ -113,6 +113,12 @@ def do_work(config, influxes):
                 }
             
     if "tapo" in config:
+        # Override the tapo logging level - the module calls logger.exception() if it fails to login to a device
+        # The problem with that is, there are now 2 possible (and incompatible) auth schemes, so login may or may
+        # not work - we don't really want log noise from something we're having to handle.
+        tapo_log = logging.getLogger('PyP100')
+        tapo_log.setLevel(logging.CRITICAL)
+                
         for tapo in config["tapo"]["devices"]:
             now_usage_w, today_usage = poll_tapo(tapo['ip'], config["tapo"]["user"], config["tapo"]["passw"])
             if now_usage_w is False:


### PR DESCRIPTION
This will put an initial fix in for #3 / [utilities/tp-link-to-influxdb#7](https://projects.bentasker.co.uk/gils_projects/issue/utilities/tp-link-to-influxdb/7.html)

After this is merged, the script will support either the `PyP100` in `pip`, or @almottier's updated fork.

There are a few differences between the two, so there's currently some special handling in place

Try and connect using `preferred_protocol="old"`:

- If the old module is in use, the function call will be considered incorrect and fail
- If the new module is in use, but the new auth method is required, this will fail

If connecting using `old` fails, then use the original invocation (if the new module is present, it'll use the new auth protocol by default).

The fork also changes the return format of `getEnergyUsage()` (moving results up a level) so there's some handling for that.

Although not required to use the new support, this PR also adds some new config options
```yaml
    devices:
        # Has a version < 1.2.1 
        # and I'm using the forked PyP100
        - 
            name: "big-fridge"
            ip : 192.168.3.153
            auth: "almottier_old"

        # Has a version >= 1.2.1 
        # and I'm using the forked PyP100
        #  Would also be valid if I firmware < 1.2.1
        # and the PyPi module was in use
        -
            name: "slow-cooker"
            ip: 192.168.3.164
            auth: "package_defaults"

        # The default behaviour - try each
        # mechanism in turn
        -
            name: "washing-machine"
            ip: 192.168.3.167
            auth: "all"
```

This allows the auth mechanism to be explicitly specified - preventing the script from wasting time trying different approaches if the plug is offline.
