### PR TITLE
fix: monkeypatch requests to raise overly short timeouts 

### DIFF
--- a/app/collect.py
+++ b/app/collect.py
@@ -25,6 +25,27 @@ CONF_FILE = os.getenv("CONF_FILE", "example/config.yml")
 log = logging.getLogger(__name__)
 #logging.basicConfig(level=logging.DEBUG)
 
+
+'''
+Interim fix added to address overly conservative timeouts used in an
+upstream PyP100 module.
+
+Monkey-patch `requests.session` so that it ignores timeouts set lower
+than our desired threshold
+
+Added in utilities/tp-link-to-influxdb#9
+''' 
+import requests
+def request_set_timeout_bound(slf, *args, **kwargs):
+    timeout = kwargs.pop('timeout', 5)
+    if timeout < 3:
+        timeout = 3
+    return slf.request_orig(*args, **kwargs, timeout=timeout)
+
+setattr(requests.sessions.Session, 'request_orig', requests.sessions.Session.request)
+requests.sessions.Session.request = request_set_timeout_bound
+
+
 def load_config():
     ''' Read the config file
     
@@ -124,7 +145,7 @@ def do_work(config, influxes):
             # Set a sane default for auth mode if it's not been specified
             if "auth" not in tapo:
                 tapo['auth'] = "all"
-                
+              
             now_usage_w, today_usage = poll_tapo(
                 tapo['ip'], 
                 config["tapo"]["user"], 


### PR DESCRIPTION
Monkeypatching `requests` to extend timeouts used by `PyP100` ([utilities/tp-link-to-influxdb#9](https://projects.bentasker.co.uk/gils_projects/issue/utilities/tp-link-to-influxdb/9.html))

This'll raise any timeout below 3 seconds to 3, and set a default timeout of 5 seconds for anything provided without a timeout

There's an upstream issue open (and likely a PR soon), which should hopefully make this a short-lived change