### PR TITLE
Implement Support for Authentication with Kasa (utilities/tp-link-to-influxdb#12)

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,7 @@ And then, finally, invoke the script
 ```sh
 app/collect.py
 ```
+----
 
 ### Loglevels
 
@@ -145,7 +146,6 @@ If further information is required during troubleshooting, log verbosity can be 
 poller:
    loglevel: "debug" 
 ```
-
 
 ----
 

--- a/example/config.yml
+++ b/example/config.yml
@@ -8,8 +8,7 @@ poller:
    interval: 20
 
 # Not routinely needed, but useful for troubleshooting
-#   loglevel: "debug"
-
+#  loglevel: "debug"
 
 # List tapo devices
 tapo:


### PR DESCRIPTION
These changes were made as a result of the report in https://github.com/bentasker/tplink_to_influxdb/issues/8

* Adds support for authenticating with Kasa devices
* Switches to `python-kasa`'s discovery mode to ensure differences in ports and handshakes are handled

The changes add definite support for Kasa EP25 devices, but should _also_ mean that we now have support for any device supported by the upstream `python-kasa` model.

This PR also introduces new configuration elements, by adding an `auth` attribute to the `kasa` section:
```yaml
kasa:
    auth:
      user: ben
      passw: SuperSecret 
 
    devices:
        -
            name: "heated-art"
            ip: 192.168.3.172
```

This section is optional and, if omitted, `python-kasa`'s default creds will be sent instead.
